### PR TITLE
fix: redirect user to the intented page

### DIFF
--- a/decidim-core/app/packs/src/decidim/append_redirect_url_to_modals.js
+++ b/decidim-core/app/packs/src/decidim/append_redirect_url_to_modals.js
@@ -53,20 +53,29 @@ $(() => {
   }
 
   $(document).on("click.zf.trigger", (event) => {
-    const target = `#${$(event.target).data("open")}`;
-    const redirectUrl = $(event.target).data("redirectUrl");
+    // Try to get the <a> directly or find the closest parent <a>
+    let $target = $(event.target);
+    if (!$target.is('a')) {
+        $target = $target.closest('a'); // Find the closest parent <a> if the click is not directly on an <a>
+    }
 
-    if (target && redirectUrl) {
-      $("<input type='hidden' />").
-        attr("id", "redirect_url").
-        attr("name", "redirect_url").
-        attr("value", redirectUrl).
-        appendTo(`${target} form`);
+    // Check if an <a> was found
+    if ($target.length) {
+        const dialogTarget = `#${$target.data("dialog-open")}`;
+        const redirectUrl = $target.data("redirectUrl");
 
-      $(`${target} a`).attr("href", (index, href) => {
-        const querystring = jQuery.param({"redirect_url": redirectUrl});
-        return href + (href.match(/\?/) ? "&" : "?") + querystring;
-      });
+        if (dialogTarget && redirectUrl) {
+            $("<input type='hidden' />")
+              .attr("id", "redirect_url")
+              .attr("name", "redirect_url")
+              .attr("value", redirectUrl)
+              .appendTo(`${dialogTarget} form`);
+
+            $(`${dialogTarget} a`).attr("href", (index, href) => {
+                const querystring = jQuery.param({"redirect_url": redirectUrl});
+                return href + (href.match(/\?/) ? "&" : "?") + querystring;
+            });
+        }
     }
   });
 


### PR DESCRIPTION
#### :tophat: What? Why?
PR to fix the redirection of the user to the intended page instead of the current page when they need it, and the login popup is required.

#### :pushpin: Related Issues

- Related to https://git.octree.ch/decidim/decidim-nightly/-/issues/18

#### Testing
* Given a Decidim proposal component configured to accept participant proposals
* As a non-registred user, I click on "New Proposal"
* I complete my login/password credentials and login
* Expected: I go on the proposal creation, as I clicked to "New Proposal"

:hearts: Thank you!
