### PR TITLE
Fix prevent js crashes from null value in messages

### DIFF
--- a/decidim-core/app/packs/src/decidim/i18n.js
+++ b/decidim-core/app/packs/src/decidim/i18n.js
@@ -25,9 +25,11 @@ export const getMessages = (key = null) => {
  * @returns {Object} The converted dictionary object
  */
 export const createDictionary = (messages, prefix = "") => {
+  if (!messages) return {};
+
   let final = {};
   Object.keys(messages).forEach((key) => {
-    if (typeof messages[key] === "object") {
+    if (messages[key] && typeof messages[key] === "object") {
       final = { ...final, ...createDictionary(messages[key], `${prefix}${key}.`) };
     } else if (key === "") {
       final[prefix?.replace(/\.$/, "") || ""] = messages[key];


### PR DESCRIPTION
#### :tophat: What? Why?
When there is a null value in var `messages`, the `i18n.js` script crashes, the WYSIWYG editor doesn't show up, and the textarea becomes disabled. 

#### :pushpin: Related Issues
[*Link your PR to an issue*](https://git.octree.ch/decidim/decidim-nightly/-/issues/70)

#### Testing


### :camera: Screenshots
![image](https://github.com/user-attachments/assets/7505a0a8-761a-4aa8-9a6a-4353e0933e16)

:hearts: Thank you!
