### PR TITLE
Fix UX for welcome and organization description in footer

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_footer.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_footer.scss
@@ -5,6 +5,14 @@ footer {
     &__top {
       @apply hidden lg:flex flex-row gap-8 container py-10;
     }
+    
+    &__text {
+      @apply text-sm text-white prose;
+
+      &__bold {
+        @apply font-bold;
+      }
+    }
 
     &__down {
       @apply border-t border-black flex flex-wrap items-center gap-6 container py-6 text-white;

--- a/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_intro.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag current_organization.attached_uploader(:official_img_footer).url, alt: current_organization_name, class: "max-h-16" %>
   <% end %>
 <% end %>
-<div class="text-sm text-white prose">
-  <p><%= t("decidim.pages.home.footer_sub_hero.footer_sub_hero_headline", organization: current_organization_name) %></p>
-  <p><%= organization_description_label %></p>
+<div class="main-footer__text">
+  <p class="main-footer__text__bold"><%= t("decidim.pages.home.footer_sub_hero.footer_sub_hero_headline", organization: current_organization_name) %></p>
+  <p><%= strip_tags(organization_description_label) %></p>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
The footer has a welcome text that is unnecessary and very difficult to read as it's dark-blue on dark-grey

#### :pushpin: Related Issues
https://git.octree.ch/decidim/decidim-nightly/-/issues/68#note_46948

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/fdbf912d-e598-4c09-9bfc-e2d584ca534b)

### :heavy_check_mark: Expected
Welcome text in white and bold
Description in white

![image](https://github.com/user-attachments/assets/f69082a9-fe45-4ce2-867c-8e1d9274d80a)


:hearts: Thank you!
