### PR TITLE
Fix UX adjustments for date and location on mobile

### DIFF
--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -16,7 +16,7 @@
       @apply flex-col md:grid md:grid-cols-[auto_1fr_1fr] items-center md:gap-0 border-4 border-background rounded overflow-hidden;
 
       > *:nth-child(2) {
-        @apply p-4 md:p-0;
+        @apply p-4;
 
         &:not(:last-child) {
           @apply col-span-2 md:col-auto order-2 md:order-1;

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -6,29 +6,17 @@
   }
 
   &__calendar {
-    @apply order-first flex flex-col justify-start rounded bg-background text-center md:w-14;
+    @apply order-first flex flex-col min-w-48 rounded bg-background text-center md:w-14;
 
     &:only-child &-month {
       @apply rounded-t;
     }
 
     &-container {
-      @apply grid grid-cols-1 md:grid-cols-[auto_1fr_1fr] items-center md:gap-0 border-4 border-background rounded overflow-hidden;
-
-      > *:nth-child(2) {
-        @apply p-4;
-
-        &:not(:last-child) {
-          @apply col-span-1 md:col-span-2 md:col-start-1 md:row-start-1;
-        }
-
-        &:last-child {
-          @apply col-span-1 md:col-span-2 md:col-start-2 pr-4;
-        }
-      }
-
-      > *:nth-child(3) {
-        @apply md:row-start-1 md:col-start-3 h-[135px];
+      @apply flex flex-wrap flex-col md:flex-row gap-2 border-4 border-background rounded;
+      
+      ul {
+        @apply flex-1 p-2;
       }
     }
 
@@ -55,7 +43,7 @@
     }
 
     &__lg {
-      @apply w-full md:flex-col md:justify-start md:h-full md:w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
+      @apply flex min-w-48;
     }
 
     &__lg &-month {

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -55,7 +55,7 @@
     }
 
     &__lg {
-      @apply w-[100%] md:w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
+      @apply w-full md:flex-col md:justify-start md:h-full md:w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
     }
 
     &__lg &-month {

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -6,14 +6,14 @@
   }
 
   &__calendar {
-    @apply w-14 flex flex-col justify-start rounded bg-background text-center;
+    @apply order-first flex flex-col justify-start rounded bg-background text-center md:w-14;
 
     &:only-child &-month {
       @apply rounded-t;
     }
 
     &-container {
-      @apply grid grid-cols-[auto_1fr] md:grid-cols-[auto_1fr_1fr] items-center gap-0 md:gap-x-5 border-4 border-background rounded overflow-hidden;
+      @apply flex-col md:grid md:grid-cols-[auto_1fr_1fr] items-center md:gap-0 border-4 border-background rounded overflow-hidden;
 
       > *:nth-child(2) {
         @apply p-4 md:p-0;
@@ -55,7 +55,7 @@
     }
 
     &__lg {
-      @apply w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
+      @apply w-[100%] md:w-fit justify-center [&>*]:px-2 min-w-24 h-[8.5rem];
     }
 
     &__lg &-month {

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -14,7 +14,7 @@
 
     &-container {
       @apply flex flex-wrap flex-col md:flex-row gap-2 border-4 border-background rounded;
-      
+
       ul {
         @apply flex-1 p-2;
       }

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -13,22 +13,22 @@
     }
 
     &-container {
-      @apply flex-col md:grid md:grid-cols-[auto_1fr_1fr] items-center md:gap-0 border-4 border-background rounded overflow-hidden;
+      @apply grid grid-cols-1 md:grid-cols-[auto_1fr_1fr] items-center md:gap-0 border-4 border-background rounded overflow-hidden;
 
       > *:nth-child(2) {
         @apply p-4;
 
         &:not(:last-child) {
-          @apply col-span-2 md:col-auto order-2 md:order-1;
+          @apply col-span-1 md:col-span-2 md:col-start-1 md:row-start-1;
         }
 
         &:last-child {
-          @apply md:col-span-2 pr-4;
+          @apply col-span-1 md:col-span-2 md:col-start-2 pr-4;
         }
       }
 
       > *:nth-child(3) {
-        @apply order-1 md:order-2 h-[135px];
+        @apply md:row-start-1 md:col-start-3 h-[135px];
       }
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
On meetings page, if the informative messages are very long, the layout on the page breaks and some elements are not visible anymore:

#### :pushpin: Related Issues
https://git.octree.ch/decidim/decidim-nightly/-/issues/79

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/e3bc3fc8-b767-4525-820b-61f5b4dbaf8d)

On Mobile   

![image](https://github.com/user-attachments/assets/eff52242-22d3-4182-a626-2313c861416a)


:hearts: Thank you!
