### PR TITLE
Fix ux adjustments on proposal's highlighted page

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -12,20 +12,20 @@
 </div>
 
 <div class="flex items-start justify-between">
-  <div class="grow space-y-6">
-    <span class="content-block__span">
-      <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
-    </span>
-
-    <% proposals_to_render.each do |p| %>
-      <%= card_for p, link_whole_card: true, title_tag: :h3, **options.slice(:show_space) %>
-    <% end %>
-  </div>
-
+  <span class="content-block__span">
+    <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
+  </span>
   <% if single_component? %>
     <%= link_to decidim_proposals.new_proposal_path, class: "button button__sm md:button__lg button__secondary" do %>
       <span><%= t("decidim.proposals.actions.new") %></span>
       <%= icon "add-line" %>
     <% end %>
   <% end %>
+</div>
+<div class="flex items-start justify-between">
+  <div class="grow space-y-6">
+    <% proposals_to_render.each do |p| %>
+      <%= card_for p, link_whole_card: true, title_tag: :h3, **options.slice(:show_space) %>
+    <% end %>
+  </div>
 </div>

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<div class="flex items-center justify-between p-2">
+<div class="flex items-center justify-between">
   <span class="content-block__span">
     <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
   </span>

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -12,12 +12,12 @@
 </div>
 
 <div class="flex items-center justify-between">
-  <span class="content-block__span">
+  <span class="content-block__span flex-shrink-0 pr-12">
     <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
   </span>
   <% if single_component? %>
     <%= link_to decidim_proposals.new_proposal_path, class: "button button__sm md:button__lg button__secondary" do %>
-      <span><%= t("decidim.proposals.actions.new") %></span>
+      <span class="text-center"><%= t("decidim.proposals.actions.new") %></span>
       <%= icon "add-line" %>
     <% end %>
   <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -11,12 +11,12 @@
   <% end %>
 </div>
 
-<div class="flex items-center justify-between">
-  <span class="content-block__span flex-shrink-0 pr-12">
+<div class="flex items-center justify-between space-x-6">
+  <span class="content-block__span flex-shrink-0">
     <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
   </span>
   <% if single_component? %>
-    <%= link_to decidim_proposals.new_proposal_path, class: "button button__sm md:button__lg button__secondary" do %>
+    <%= link_to decidim_proposals.new_proposal_path, class: "button button__xs md:button__lg button__secondary" do %>
       <span class="text-center"><%= t("decidim.proposals.actions.new") %></span>
       <%= icon "add-line" %>
     <% end %>

--- a/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/highlighted_proposals_for_component/show.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<div class="flex items-start justify-between">
+<div class="flex items-center justify-between p-2">
   <span class="content-block__span">
     <%= t("decidim.participatory_spaces.highlighted_proposals.last") %>
   </span>


### PR DESCRIPTION
#### :tophat: What? Why?
On Mobile, on a Process page:
The layout of the listing of Proposals is not optimal. A lot of width is lost for the actual list of proposals.

#### :pushpin: Related Issues
https://git.octree.ch/decidim/decidim-nightly/-/issues/85

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/5eb858a5-3d98-423e-b825-e4eba0b66a3d)


:hearts: Thank you!
