### PR TITLE
Fix incorrect breadcrumb encoding on mobile and tablet

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -2,7 +2,7 @@
 <div class="menu-bar__breadcrumb-mobile__dropdown-trigger">
   <span>
     <% breadcrumb_items.last(2).each_with_index do |item, i| %>
-      <% item_label = decidim_escape_translated(item[:label]) %>
+      <% item_label = decidim_escape_translated(item[:label]).html_safe %>
       <% if i.positive? %>
         <span>/</span>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?   
Breadcrumb for mobile is escaped without html_safe, and for desktop, it is displayed without using the escape method. 

#### :pushpin: Related Issues
https://git.octree.ch/decidim/decidim-nightly/-/issues/68#note_46918

#### Testing
Create an proposal named, for example: "Partage d'idées"

### :camera: Screenshots
![image](https://github.com/user-attachments/assets/b7b3ef17-4912-4117-8e2f-4cbb2fbc621c)

:hearts: Thank you!
