### PR TITLE
Do not attach avatar on omniauth registration if avatar_url is unreachable

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -70,10 +70,14 @@ module Decidim
         @user.newsletter_notifications_at = nil
         @user.password = SecureRandom.hex
         if form.avatar_url.present?
-          url = URI.parse(form.avatar_url)
-          filename = File.basename(url.path)
-          file = url.open
-          @user.avatar.attach(io: file, filename:)
+          begin
+            url = URI.parse(form.avatar_url)
+            filename = File.basename(url.path)
+            file = url.open
+            @user.avatar.attach(io: file, filename:)
+          rescue OpenURI::HTTPError, Errno::ECONNREFUSED => e
+            # Do not attach the avatar, as it fails to fetch it.
+          end
         end
         @user.tos_agreement = form.tos_agreement
         @user.accepted_tos_version = Time.current

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -69,16 +69,7 @@ module Decidim
         @user.nickname = form.normalized_nickname
         @user.newsletter_notifications_at = nil
         @user.password = SecureRandom.hex
-        if form.avatar_url.present?
-          begin
-            url = URI.parse(form.avatar_url)
-            filename = File.basename(url.path)
-            file = url.open
-            @user.avatar.attach(io: file, filename:)
-          rescue OpenURI::HTTPError, Errno::ECONNREFUSED => e
-            # Do not attach the avatar, as it fails to fetch it.
-          end
-        end
+        attach_avatar(form.avatar_url) if form.avatar_url.present?
         @user.tos_agreement = form.tos_agreement
         @user.accepted_tos_version = Time.current
         raise NeedTosAcceptance if @user.tos_agreement.blank?
@@ -87,6 +78,15 @@ module Decidim
         @user.save!
         @user.after_confirmation if verified_email
       end
+    end
+
+    def attach_avatar(avatar_url)
+      url = URI.parse(avatar_url)
+      filename = File.basename(url.path)
+      file = url.open
+      @user.avatar.attach(io: file, filename:)
+    rescue OpenURI::HTTPError, Errno::ECONNREFUSED
+      # Do not attach the avatar, as it fails to fetch it.
     end
 
     def create_identity

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -87,6 +87,16 @@ module Decidim
             expect(user.valid_password?("decidim123456789")).to be(true)
           end
 
+          it "ignores avatar url if URL is not readable" do 
+            stub_request(:get, "http://www.example.com/foo.jpg")
+            .to_return(status: 404)
+        
+            expect { command.call }.to broadcast(:ok)
+        
+            user = User.find_by(email: form.email)
+            expect(user.avatar.attached?).to be_falsey
+          end
+          
           # NOTE: This is important so that the users who are only
           # authenticating using omniauth will not need to update their
           # passwords.

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -87,6 +87,18 @@ module Decidim
             expect(user.valid_password?("decidim123456789")).to be(true)
           end
 
+          it "download and attach the avatar" do
+            stub_request(:get, "http://www.example.com/foo.jpg").to_return(
+              status: 200,
+              body: File.read("spec/assets/avatar.jpg"), headers: { "Content-Type" => "image/jpeg" }
+            )
+            expect { command.call }.to broadcast(:ok)
+            user = User.find_by(email: form.email)
+            expect(user.avatar).to be_attached
+            expect(user.avatar.attachment.filename.to_s).to eq("foo.jpg")
+            expect(user.avatar.attachment.blob.byte_size).to eq(File.open("spec/assets/avatar.jpg").size)
+          end
+
           context "when avatar URL fetching fails" do
             it "with a 404 HTTP code, it saves the user without avatar" do
               stub_request(:get, "http://www.example.com/foo.jpg").to_return(status: 404)


### PR DESCRIPTION
#### :tophat: What? Why?
When users login with external login, the OAuth2 server might gives an avatar_url that is not reachable. 
This happens using Auth0 when a user have no avatar, Auth0 give back an avatar_url that gives a 404.

#### :pushpin: Related Issues
*Link your PR to an issue*


#### Testing
*Describe the best way to test or validate your PR.*
Setting up an Auht0 provider, and register your user without any avatar. Auth0 will gives in the payload a default avatar_url that is not accessible, at least  in a server-to-server mode. 


:hearts: Thank you!
