### PR TITLE
Add notification to authors when the proposal is accepted

### DIFF
--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -44,6 +44,7 @@ module Decidim
 
     def send_to_affected_users
       affected_users.each do |recipient|
+        next unless recipient.respond_to?(:notification_types)
         next unless ["all", "own-only"].include?(recipient.notification_types)
         next if recipient.deleted? || recipient.blocked?
 

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -41,6 +41,7 @@ module Decidim
       end
 
       affected_users.each do |recipient|
+        next unless recipient.respond_to?(:notification_types)
         generate_notification_for(recipient, user_role: :affected_user) if ["all", "own-only"].include?(recipient.notification_types)
       end
     end

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -42,6 +42,7 @@ module Decidim
 
       affected_users.each do |recipient|
         next unless recipient.respond_to?(:notification_types)
+
         generate_notification_for(recipient, user_role: :affected_user) if ["all", "own-only"].include?(recipient.notification_types)
       end
     end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
@@ -27,6 +27,7 @@ module Decidim
             transaction do
               increment_score
               notify_followers
+              notify_authors
             end
           end
 
@@ -43,13 +44,23 @@ module Decidim
 
         def notify_followers
           return if proposal.state == "not_answered"
-
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_state_changed",
             event_class: Decidim::Proposals::ProposalStateChangedEvent,
             resource: proposal,
             affected_users: proposal.notifiable_identities,
             followers: proposal.followers - proposal.notifiable_identities
+          )
+        end
+
+        def notify_authors
+          return if proposal.state == "not_answered"
+          Decidim::EventsManager.publish(
+            event: "decidim.events.proposals.proposal_state_changed_for_authors",
+            event_class: Decidim::Proposals::ProposalStateChangedEvent,
+            resource: proposal,
+            affected_users: proposal.authors,
+            extra: { force_email: true }
           )
         end
 

--- a/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/notify_proposal_answer.rb
@@ -44,6 +44,7 @@ module Decidim
 
         def notify_followers
           return if proposal.state == "not_answered"
+
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_state_changed",
             event_class: Decidim::Proposals::ProposalStateChangedEvent,
@@ -55,6 +56,7 @@ module Decidim
 
         def notify_authors
           return if proposal.state == "not_answered"
+
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_state_changed_for_authors",
             event_class: Decidim::Proposals::ProposalStateChangedEvent,

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -371,6 +371,12 @@ en:
             email_outro: You have received this notification because you are following "%{resource_title}". You can unfollow it from the previous link.
             email_subject: A proposal you are following has changed its state (%{state})
             notification_title: The <a href="%{resource_path}">%{resource_title}</a> proposal has changed its state to "%{state}".
+        proposal_state_changed_for_authors:
+          affected_user:
+            email_intro: 'The proposal "%{resource_title}" has changed its state to "%{state}". You can read the answer in this page:'
+            email_outro: You have received this notification because you are an author of "%{resource_title}".
+            email_subject: Your proposal has changed its state (%{state})
+            notification_title: Your proposal <a href="%{resource_path}">%{resource_title}</a> has changed its state to "%{state}".
         proposal_update_taxonomies:
           email_intro: 'An admin has updated the taxonomies of your proposal "%{resource_title}", check it out in this page:'
           email_outro: You have received this notification because you are the author of the proposal.

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
@@ -20,6 +20,8 @@ module Decidim
 
           # give proposal author initial points to avoid unwanted events during tests
           Decidim::Gamification.increment_score(proposal.creator_author, :accepted_proposals)
+
+          allow(Decidim::EventsManager).to receive(:publish)
         end
 
         it "broadcasts ok" do
@@ -38,6 +40,24 @@ module Decidim
             )
 
           subject
+        end
+
+        context "when the authors is notified too" do
+          it "notifies the proposal authors" do
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                hash_including(
+                  event: "decidim.events.proposals.proposal_state_changed_for_authors",
+                  event_class: Decidim::Proposals::ProposalStateChangedEvent,
+                  resource: proposal,
+                  affected_users: match_array(proposal.authors),
+                  extra: { force_email: true }
+                )
+              )
+
+            subject
+          end
         end
 
         it "increments the accepted proposals counter" do
@@ -66,6 +86,24 @@ module Decidim
             subject
           end
 
+          context "when the authors is notified too" do
+            it "notifies the proposal authors" do
+              expect(Decidim::EventsManager)
+                .to receive(:publish)
+                .with(
+                  hash_including(
+                    event: "decidim.events.proposals.proposal_state_changed_for_authors",
+                    event_class: Decidim::Proposals::ProposalStateChangedEvent,
+                    resource: proposal,
+                    affected_users: match_array(proposal.authors),
+                    extra: { force_email: true }
+                  )
+                )
+
+              subject
+            end
+          end
+
           it "decrements the accepted proposals counter" do
             expect { subject }.to change { Gamification.status_for(proposal.coauthorships.first.author, :accepted_proposals).score }.by(-1)
           end
@@ -86,6 +124,15 @@ module Decidim
             subject
           end
 
+          context "when the authors is notified too" do
+            it "does not notify the proposal authors" do
+              expect(Decidim::EventsManager)
+                .not_to receive(:publish)
+
+              subject
+            end
+          end
+
           it "decrements the accepted proposals counter" do
             expect { subject }.to change { Gamification.status_for(proposal.coauthorships.first.author, :accepted_proposals).score }.by(-1)
           end
@@ -103,6 +150,15 @@ module Decidim
               .not_to receive(:publish)
 
             subject
+          end
+
+          context "when the authors is notified too" do
+            it "does not notify the proposal authors" do
+              expect(Decidim::EventsManager)
+                .not_to receive(:publish)
+
+              subject
+            end
           end
 
           it "does not modify the accepted proposals counter" do

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
@@ -42,8 +42,8 @@ module Decidim
           subject
         end
 
-        context "when the authors is notified too" do
-          it "notifies the proposal authors" do
+        context "when the creator_author needs to be notified" do
+          it "notifies the proposal to creator_author" do
             expect(Decidim::EventsManager)
               .to receive(:publish)
               .with(
@@ -86,8 +86,8 @@ module Decidim
             subject
           end
 
-          context "when the authors is notified too" do
-            it "notifies the proposal authors" do
+          context "when the creator_author needs to be notified" do
+            it "notifies the proposal to creator_author" do
               expect(Decidim::EventsManager)
                 .to receive(:publish)
                 .with(
@@ -124,8 +124,8 @@ module Decidim
             subject
           end
 
-          context "when the authors is notified too" do
-            it "does not notify the proposal authors" do
+          context "when the creator_author doesn't need to be notified" do
+            it "does not notify the proposal creator_author" do
               expect(Decidim::EventsManager)
                 .not_to receive(:publish)
 
@@ -152,8 +152,8 @@ module Decidim
             subject
           end
 
-          context "when the authors is notified too" do
-            it "does not notify the proposal authors" do
+          context "when the creator_author doesn't need to be notified" do
+            it "does not notify the proposal creator_author" do
               expect(Decidim::EventsManager)
                 .not_to receive(:publish)
 

--- a/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin/notify_proposal_answer_spec.rb
@@ -124,7 +124,7 @@ module Decidim
             subject
           end
 
-          context "when the creator_author doesn't need to be notified" do
+          context "when the creator_author does not need to be notified" do
             it "does not notify the proposal creator_author" do
               expect(Decidim::EventsManager)
                 .not_to receive(:publish)
@@ -152,7 +152,7 @@ module Decidim
             subject
           end
 
-          context "when the creator_author doesn't need to be notified" do
+          context "when the creator_author does not need to be notified" do
             it "does not notify the proposal creator_author" do
               expect(Decidim::EventsManager)
                 .not_to receive(:publish)


### PR DESCRIPTION
#### :tophat: What? Why?
After a proposal is accepted, the user who created it doesn't receive any email notification.
This PR aims to fix it by sending an email notification to the authors regardless of their notification settings.

#### :pushpin: Related Issues
https://github.com/decidim/decidim/issues/15829

#### Testing
Validation steps
 - As a participant, create and publish a proposal
 - As an admin, go to the published proposal  and change its state to "Accepted"
 - As the participant, check the e-mail

:hearts: Thank you!
